### PR TITLE
Fix aspect ratio when sourceSize is used

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,8 +9,8 @@ platform:
   - x64
 
 environment:
-  QT5: C:\Qt\5.11.0\msvc2015_64 
-  APPVEYOR_SAVE_CACHE_ON_ERROR: true
+  QT5: C:\Qt\5.11.1\msvc2015_64
+  # APPVEYOR_SAVE_CACHE_ON_ERROR: true
 
 install:
   - vcpkg list

--- a/src/depthMapEntity/DepthMapEntity.cpp
+++ b/src/depthMapEntity/DepthMapEntity.cpp
@@ -19,6 +19,7 @@
 #include <Qt3DRender/QBuffer>
 #include <Qt3DCore/QTransform>
 
+#include <QDebug>
 
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/imagebuf.h>
@@ -71,7 +72,8 @@ DepthMapEntity::DepthMapEntity(Qt3DCore::QNode* parent)
     : Qt3DCore::QEntity(parent)
     , _displayMode(DisplayMode::Unknown)
 {
-    std::cout << "[DepthMapEntity] Constructor" << std::endl;
+    std::cout << "[DepthMapEntity] DepthMapEntity" << std::endl;
+    qDebug() << "[DepthMapEntity] DepthMapEntity";
     setDisplayMode(DisplayMode::Triangles);
 }
 
@@ -522,11 +524,11 @@ bool validTriangleRatio(const Vec3f& a, const Vec3f& b, const Vec3f& c)
 // private
 void DepthMapEntity::loadDepthMap()
 {
-    std::cout << "[DepthMapEntity] loadDepthMap" << std::endl;
+    qDebug() << "[DepthMapEntity] loadDepthMap";
     if(!_source.isValid())
         return;
 
-    std::cout << "[DepthMapEntity] Load Depth Map: " << _source.path().toStdString() << std::endl;
+    qDebug() << "[DepthMapEntity] Load Depth Map: " << _source.path();
 
     using namespace Qt3DRender;
 
@@ -540,39 +542,39 @@ void DepthMapEntity::loadDepthMap()
     oiio::ImageBuf inBuf(_source.path().toStdString(), 0, 0, NULL, &configSpec);
     const oiio::ImageSpec& inSpec = inBuf.spec();
 
-    std::cout << "[DepthMapEntity] Image Size: " << inSpec.width << "x" << inSpec.height << std::endl;
+    qDebug() << "[DepthMapEntity] Image Size: " << inSpec.width << "x" << inSpec.height;
 
     point3d CArr;
     const oiio::ParamValue * cParam = inSpec.find_attribute("AliceVision:CArr"); // , oiio::TypeDesc(oiio::TypeDesc::DOUBLE, oiio::TypeDesc::VEC3));
     if(cParam)
     {
-        std::cout << "[DepthMapEntity] CArr: " << cParam->nvalues() << std::endl;
+        qDebug() << "[DepthMapEntity] CArr: " << cParam->nvalues();
         std::copy_n((const double*)cParam->data(), 3, CArr.m);
         CArr.doprintf();
     }
     else
     {
-        std::cout << "[DepthMapEntity] missing metadata CArr." << std::endl;
+        qDebug() << "[DepthMapEntity] missing metadata CArr.";
     }
 
     matrix3x3 iCamArr;
     const oiio::ParamValue * icParam = inSpec.find_attribute("AliceVision:iCamArr", oiio::TypeDesc(oiio::TypeDesc::DOUBLE, oiio::TypeDesc::MATRIX33));
     if(icParam)
     {
-        std::cout << "[DepthMapEntity] iCamArr: " << icParam->nvalues() << std::endl;
+        qDebug() << "[DepthMapEntity] iCamArr: " << icParam->nvalues();
         std::copy_n((const double*)icParam->data(), 9, iCamArr.m);
         iCamArr.doprintf();
     }
     else
     {
-        std::cout << "[DepthMapEntity] missing metadata iCamArr." << std::endl;
+        qDebug() << "[DepthMapEntity] missing metadata iCamArr.";
     }
 
     QString simPath = _source.path().replace("depthMap", "simMap");
     oiio::ImageBuf simBuf;
     if(QUrl(simPath).isValid())
     {
-        std::cout << "[DepthMapEntity] Load Sim Map: " << simPath.toStdString() << std::endl;
+        qDebug() << "[DepthMapEntity] Load Sim Map: " << simPath;
         simBuf.reset(simPath.toStdString(), 0, 0, NULL, &configSpec);
     }
     const oiio::ImageSpec& simSpec = simBuf.spec();
@@ -621,7 +623,7 @@ void DepthMapEntity::loadDepthMap()
         }
     }
 
-    std::cout << "[DepthMapEntity] Valid Depth Values: " << positions.size() << std::endl;
+    qDebug() << "[DepthMapEntity] Valid Depth Values: " << positions.size();
 
     // create a new geometry renderer
     QGeometryRenderer* customMeshRenderer = new QGeometryRenderer;
@@ -660,7 +662,7 @@ void DepthMapEntity::loadDepthMap()
                 }
             }
         }
-        std::cout << "[DepthMapEntity] Nb triangles: " << trianglesIndexes.size() << std::endl;
+        qDebug() << "[DepthMapEntity] Nb triangles: " << trianglesIndexes.size();
     }
 #ifndef QTOIIO_DEPTHMAP_USE_INDEXES
     if(_displayMode == DisplayMode::Triangles)
@@ -718,7 +720,7 @@ void DepthMapEntity::loadDepthMap()
         colorDataBuffer->setData(colorData);
 
         QAttribute* colorAttribute = new QAttribute;
-        std::cout << "Qt3DRender::QAttribute::defaultColorAttributeName(): " << Qt3DRender::QAttribute::defaultColorAttributeName().toStdString() << std::endl;
+        qDebug() << "Qt3DRender::QAttribute::defaultColorAttributeName(): " << Qt3DRender::QAttribute::defaultColorAttributeName().toStdString();
         colorAttribute->setName(Qt3DRender::QAttribute::defaultColorAttributeName());
         colorAttribute->setAttributeType(QAttribute::VertexAttribute);
         colorAttribute->setBuffer(colorDataBuffer);
@@ -745,7 +747,7 @@ void DepthMapEntity::loadDepthMap()
         colorDataBuffer->setData(colorData);
 
         QAttribute* colorAttribute = new QAttribute;
-        std::cout << "Qt3DRender::QAttribute::defaultColorAttributeName(): " << Qt3DRender::QAttribute::defaultColorAttributeName().toStdString() << std::endl;
+        qDebug() << "Qt3DRender::QAttribute::defaultColorAttributeName(): " << Qt3DRender::QAttribute::defaultColorAttributeName();
         colorAttribute->setName(Qt3DRender::QAttribute::defaultColorAttributeName());
         colorAttribute->setAttributeType(QAttribute::VertexAttribute);
         colorAttribute->setBuffer(colorDataBuffer);
@@ -851,7 +853,7 @@ void DepthMapEntity::loadDepthMap()
     addComponent(_cloudMaterial);
     addComponent(transform);
     addComponent(customMeshRenderer);
-    std::cout << "DepthMapEntity: Mesh Renderer added." << std::endl;
+    qDebug() << "DepthMapEntity: Mesh Renderer added.";
 }
 
 } // namespace

--- a/src/imageIOHandler/QtOIIOHandler.cpp
+++ b/src/imageIOHandler/QtOIIOHandler.cpp
@@ -7,6 +7,7 @@
 #include <QFileDevice>
 #include <QVariant>
 #include <QDataStream>
+#include <QDebug>
 
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/imagebuf.h>
@@ -19,7 +20,7 @@ namespace oiio = OIIO;
 
 QtOIIOHandler::QtOIIOHandler()
 {
-    std::cout << "[QtOIIO] QtOIIOHandler" << std::endl;
+    qInfo() << "[QtOIIO] QtOIIOHandler";
 }
 
 QtOIIOHandler::~QtOIIOHandler()
@@ -41,10 +42,10 @@ bool QtOIIOHandler::canRead(QIODevice *device)
     QFileDevice* d = dynamic_cast<QFileDevice*>(device);
     if(d)
     {
-        // std::cout << "[QtOIIO] Can read file: " << d->fileName().toStdString() << std::endl;
+        // qDebug() << "[QtOIIO] Can read file: " << d->fileName().toStdString();
         return true;
     }
-    // std::cout << "[QtOIIO] Cannot read." << std::endl;
+    // qDebug() << "[QtOIIO] Cannot read.";
     return false;
 }
 
@@ -52,16 +53,16 @@ bool QtOIIOHandler::read(QImage *image)
 {
     bool convertGrayscaleToJetColorMap = true; // how to expose it as an option?
 
-    // std::cout << "[QtOIIO] Read Image" << std::endl;
+    // qDebug() << "[QtOIIO] Read Image";
     QFileDevice* d = dynamic_cast<QFileDevice*>(device());
     if(!d)
     {
-        std::cout << "[QtOIIO] Read image failed (not a FileDevice)." << std::endl;
+        qWarning() << "[QtOIIO] Read image failed (not a FileDevice).";
         return false;
     }
     const std::string path = d->fileName().toStdString();
 
-    std::cout << "[QtOIIO] Read image: " << path << std::endl;
+    qInfo() << "[QtOIIO] Read image: " << path.c_str();
     // check requested channels number
     // assert(nchannels == 1 || nchannels >= 3);
 
@@ -79,7 +80,7 @@ bool QtOIIOHandler::read(QImage *image)
 
     oiio::ImageSpec inSpec = inBuf.spec();
 
-    std::cout << "[QtOIIO] width:" << inSpec.width << ", height:" << inSpec.height << ", nchannels:" << inSpec.nchannels << std::endl;
+    qDebug() << "[QtOIIO] width:" << inSpec.width << ", height:" << inSpec.height << ", nchannels:" << inSpec.nchannels;
 
     int nchannels = 0;
     QImage::Format format = QImage::NImageFormats;
@@ -108,11 +109,11 @@ bool QtOIIOHandler::read(QImage *image)
     }
     else
     {
-        std::cout << "[QtOIIO] failed to load \"" << path << "\", nchannels=" << inSpec.nchannels << std::endl;
+        qWarning() << "[QtOIIO] failed to load \"" << path.c_str() << "\", nchannels=" << inSpec.nchannels;
         return false;
     }
 
-    std::cout << "[QtOIIO] nchannels:" << nchannels << std::endl;
+    qDebug() << "[QtOIIO] nchannels:" << nchannels;
 
     // check picture channels number
     if(inSpec.nchannels < 3 && inSpec.nchannels != 1)
@@ -120,7 +121,7 @@ bool QtOIIOHandler::read(QImage *image)
 
     if(inBuf.orientation() != 1) // 1 is "normal", no re-orientation to do
     {
-        std::cout << "[QtOIIO] reorient image \"" << path << "\"." << std::endl;
+        qDebug() << "[QtOIIO] reorient image \"" << path.c_str() << "\".";
         oiio::ImageBuf reorientedBuf;
         oiio::ImageBufAlgo::reorient(reorientedBuf, inBuf);
         inBuf.swap(reorientedBuf);
@@ -169,7 +170,7 @@ bool QtOIIOHandler::read(QImage *image)
         const std::string colorMapType = colorMapEnv ? colorMapEnv : "plasma";
         if(colorMapEnv)
         {
-            std::cout << "[QtOIIO] compute colormap \"" << colorMapType << "\"" << std::endl;
+            qDebug() << "[QtOIIO] compute colormap \"" << colorMapType.c_str() << "\"";
             oiio::ImageBufAlgo::color_map(tmpBuf, inBuf, 0, colorMapType);
         }
         else if(d->fileName().contains("depthMap"))
@@ -223,24 +224,24 @@ bool QtOIIOHandler::read(QImage *image)
                 }
             }
         }
-        // std::cout << "[QtOIIO] compute colormap done" << std::endl;
+        // qDebug() << "[QtOIIO] compute colormap done";
         inBuf.swap(tmpBuf);
     }
 
     // Shuffle channels to convert from OIIO to Qt
     else if(nchannels == 4)
     {
-        // std::cout << "[QtOIIO] shuffle channels" << std::endl;
+        // qDebug() << "[QtOIIO] shuffle channels";
         oiio::ImageSpec requestedSpec(inSpec.width, inSpec.height, nchannels, typeDesc);
         oiio::ImageBuf tmpBuf(requestedSpec);
 
         const std::vector<int> channelOrder = {2, 1, 0, 3}; // This one works, not sure why...
         oiio::ImageBufAlgo::channels(tmpBuf, inBuf, 4, &channelOrder.front());
         inBuf.swap(tmpBuf);
-        // std::cout << "[QtOIIO] shuffle channels done" << std::endl;
+        // qDebug() << "[QtOIIO] shuffle channels done";
     }
 
-    // std::cout << "[QtOIIO] create output QImage" << std::endl;
+    // qDebug() << "[QtOIIO] create output QImage";
     QImage result(inSpec.width, inSpec.height, format);
 
     {
@@ -248,14 +249,14 @@ bool QtOIIOHandler::read(QImage *image)
         exportROI.chbegin = 0;
         exportROI.chend = nchannels;
 
-        // std::cout << "[QtOIIO] fill output QImage" << std::endl;
+        // qDebug() << "[QtOIIO] fill output QImage";
         inBuf.get_pixels(exportROI, typeDesc, result.bits());
     }
 
-    // std::cout << "[QtOIIO] Image loaded: \"" << path << "\"" << std::endl;
+    // qDebug() << "[QtOIIO] Image loaded: \"" << path << "\"";
     if (_scaledSize.isValid())
     {
-        std::cout << "[QTOIIO] _scaledSize: " << _scaledSize.width() << "x" << _scaledSize.height() << std::endl;
+        qDebug() << "[QTOIIO] _scaledSize: " << _scaledSize.width() << "x" << _scaledSize.height();
         *image = result.scaled(_scaledSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
     }
     else
@@ -290,7 +291,7 @@ QVariant QtOIIOHandler::option(ImageOption option) const
         QFileDevice* d = dynamic_cast<QFileDevice*>(device());
         if(!d)
         {
-            std::cout << "[QtOIIO] Read image failed (not a FileDevice)." << std::endl;
+            qDebug() << "[QtOIIO] Read image failed (not a FileDevice).";
             return false;
         }
         std::string path = d->fileName().toStdString();
@@ -311,7 +312,7 @@ void QtOIIOHandler::setOption(ImageOption option, const QVariant &value)
     if (option == ScaledSize && value.isValid())
     {
         _scaledSize = value.value<QSize>();
-        std::cout << "[QTOIIO] setOption scaledSize: " << _scaledSize.width() << "x" << _scaledSize.height() << std::endl;
+        qDebug() << "[QTOIIO] setOption scaledSize: " << _scaledSize.width() << "x" << _scaledSize.height();
     }
 }
 

--- a/src/imageIOHandler/QtOIIOHandler.cpp
+++ b/src/imageIOHandler/QtOIIOHandler.cpp
@@ -253,7 +253,15 @@ bool QtOIIOHandler::read(QImage *image)
     }
 
     // std::cout << "[QtOIIO] Image loaded: \"" << path << "\"" << std::endl;
-    *image = result;
+    if (_scaledSize.isValid())
+    {
+        std::cout << "[QTOIIO] _scaledSize: " << _scaledSize.width() << "x" << _scaledSize.height() << std::endl;
+        *image = result.scaled(_scaledSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    }
+    else
+    {
+        *image = result;
+    }
     return true;
 }
 
@@ -269,6 +277,9 @@ bool QtOIIOHandler::supportsOption(ImageOption option) const
         return true;
     if(option == TransformedByDefault)
         return true;
+    if(option == ScaledSize)
+        return true;
+
     return false;
 }
 
@@ -290,13 +301,18 @@ QVariant QtOIIOHandler::option(ImageOption option) const
 
         return QSize(imageInput->spec().width, imageInput->spec().height);
     }
-    return QVariant();
+    return QImageIOHandler::option(option);
 }
 
 void QtOIIOHandler::setOption(ImageOption option, const QVariant &value)
 {
     Q_UNUSED(option);
     Q_UNUSED(value);
+    if (option == ScaledSize && value.isValid())
+    {
+        _scaledSize = value.value<QSize>();
+        std::cout << "[QTOIIO] setOption scaledSize: " << _scaledSize.width() << "x" << _scaledSize.height() << std::endl;
+    }
 }
 
 QByteArray QtOIIOHandler::name() const

--- a/src/imageIOHandler/QtOIIOHandler.hpp
+++ b/src/imageIOHandler/QtOIIOHandler.hpp
@@ -19,4 +19,6 @@ public:
     QVariant option(ImageOption option) const;
     void setOption(ImageOption option, const QVariant &value);
     bool supportsOption(ImageOption option) const;
+
+    QSize _scaledSize;
 };

--- a/src/imageIOHandler/QtOIIOPlugin.cpp
+++ b/src/imageIOHandler/QtOIIOPlugin.cpp
@@ -3,6 +3,7 @@
 
 #include <qimageiohandler.h>
 #include <QFileDevice>
+#include <QDebug>
 
 #include <OpenImageIO/imageio.h>
 
@@ -12,30 +13,29 @@ namespace oiio = OIIO;
 
 QtOIIOPlugin::QtOIIOPlugin()
 {
-    std::cout << "[QtOIIO] init supported extensions." << std::endl;
+    qInfo() << "[QtOIIO] init supported extensions.";
 
     std::string extensionsListStr;
     oiio::getattribute("extension_list", extensionsListStr);
 
     QString extensionsListQStr(QString::fromStdString(extensionsListStr));
-
-    std::cout << "[QtOIIO] extensionsListQStr: " << extensionsListQStr.toStdString() << "." << std::endl;
-    std::cout << "[QtOIIO] extensionsListStr: " << extensionsListStr << "." << std::endl;
+    // qInfo() << "[QtOIIO] extensionsListStr: " << extensionsListQStr << ".";
 
     QStringList formats = extensionsListQStr.split(';');
     for(auto& format: formats)
     {
-        std::cout << "[QtOIIO] format: " << format.toStdString() << "." << std::endl;
+        qInfo() << "[QtOIIO] format: " << format << ".";
         QStringList keyValues = format.split(":");
         if(keyValues.size() != 2)
         {
-            std::cout << "[QtOIIO] warning: split OIIO keys: " << keyValues.size() << " for " << format.toStdString() << "." << std::endl;
+            qInfo() << "[QtOIIO] warning: split OIIO keys: " << keyValues.size() << " for " << format << ".";
         }
         else
         {
             _supportedExtensions += keyValues[1].split(",");
         }
     }
+    qInfo() << "[QtOIIO] supported extensions: " << _supportedExtensions.join(", ");
     std::cout << "[QtOIIO] supported extensions: " << _supportedExtensions.join(", ").toStdString() << std::endl;
 }
 
@@ -55,7 +55,7 @@ QImageIOPlugin::Capabilities QtOIIOPlugin::capabilities(QIODevice *device, const
 
     if (_supportedExtensions.contains(format, Qt::CaseSensitivity::CaseInsensitive))
     {
-        std::cout << "[QtOIIO] Capabilities: extension \"" << QString(format).toStdString() << "\" supported." << std::endl;
+        qInfo() << "[QtOIIO] Capabilities: extension \"" << QString(format) << "\" supported.";
 //        oiio::ImageOutput *out = oiio::ImageOutput::create(path); // TODO: when writting will be implemented
         Capabilities capabilities(CanRead);
 //        if(out)
@@ -63,7 +63,7 @@ QImageIOPlugin::Capabilities QtOIIOPlugin::capabilities(QIODevice *device, const
 //        oiio::ImageOutput::destroy(out);
         return capabilities;
     }
-    std::cout << "[QtOIIO] Capabilities: extension \"" << QString(format).toStdString() << "\" not supported" << std::endl;
+    qInfo() << "[QtOIIO] Capabilities: extension \"" << QString(format) << "\" not supported";
     return 0;
 }
 


### PR DESCRIPTION
Add support for `ScaledSize` option in the imageio plugin to avoid aspect ratio problems.
If it is not supported by the plugin, the fallback in qimageiohandler use Qt::IgnoreAspectRatio during the resize. This option is used when we set a `sourceSize` in QML.
