### PR TITLE
Fix linux build.

### DIFF
--- a/src/jetColorMap.hpp
+++ b/src/jetColorMap.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cmath>
 
 static float jetr[64] = {0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,
                          0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,


### PR DESCRIPTION
Plugin won't build on Linux (gcc:8.2,qt:5.11) : gcc complains about std::modf beeing undefined. 