### PR TITLE
Disable support of some image formats for performance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,10 @@ add_definitions(-DQT_NO_DEBUG)
 # comment to get qDebug outputs
 add_definitions(-DQT_NO_DEBUG_OUTPUT)
 
+# comment to handle all possible file formats
+# by default: jpeg, png and ico are handled by Qt (for performance reasons)
+add_definitions(-DQTOIIO_USE_FORMATS_BLACKLIST)
+
 add_subdirectory(src/imageIOHandler)
 add_subdirectory(src/depthMapEntity)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,9 @@ add_definitions(-DQT_PLUGIN)
 add_definitions(-DQT_SHARED)
 add_definitions(-DQT_NO_DEBUG)
 
+# comment to get qDebug outputs
+add_definitions(-DQT_NO_DEBUG_OUTPUT)
+
 add_subdirectory(src/imageIOHandler)
 add_subdirectory(src/depthMapEntity)
 

--- a/src/imageIOHandler/CMakeLists.txt
+++ b/src/imageIOHandler/CMakeLists.txt
@@ -22,9 +22,8 @@ target_link_libraries(QtOIIOPlugin
 if(Qt5Core_FOUND)
   target_link_libraries(QtOIIOPlugin
       PUBLIC
-      Qt5::Core Qt5::Widgets
+      Qt5::Core Qt5::Gui
       )
 endif()
 
 install(TARGETS QtOIIOPlugin DESTINATION imageformats)
-install(FILES QtOIIOPlugin.json DESTINATION imageformats)

--- a/src/imageIOHandler/QtOIIOHandler.cpp
+++ b/src/imageIOHandler/QtOIIOHandler.cpp
@@ -20,7 +20,7 @@ namespace oiio = OIIO;
 
 QtOIIOHandler::QtOIIOHandler()
 {
-    qInfo() << "[QtOIIO] QtOIIOHandler";
+    qDebug() << "[QtOIIO] QtOIIOHandler";
 }
 
 QtOIIOHandler::~QtOIIOHandler()

--- a/src/imageIOHandler/QtOIIOHandler.cpp
+++ b/src/imageIOHandler/QtOIIOHandler.cpp
@@ -119,15 +119,6 @@ bool QtOIIOHandler::read(QImage *image)
     if(inSpec.nchannels < 3 && inSpec.nchannels != 1)
         throw std::runtime_error("Can't load channels of image file '" + path + "'.");
 
-    if(inBuf.orientation() != 1) // 1 is "normal", no re-orientation to do
-    {
-        qDebug() << "[QtOIIO] reorient image \"" << path.c_str() << "\".";
-        oiio::ImageBuf reorientedBuf;
-        oiio::ImageBufAlgo::reorient(reorientedBuf, inBuf);
-        inBuf.swap(reorientedBuf);
-        inSpec = inBuf.spec();
-    }
-
 //    // convert to grayscale if needed
 //    if(nchannels == 1 && inSpec.nchannels >= 3)
 //    {
@@ -276,7 +267,7 @@ bool QtOIIOHandler::supportsOption(ImageOption option) const
 {
     if(option == Size)
         return true;
-    if(option == TransformedByDefault)
+    if(option == ImageTransformation)
         return true;
     if(option == ScaledSize)
         return true;
@@ -286,21 +277,44 @@ bool QtOIIOHandler::supportsOption(ImageOption option) const
 
 QVariant QtOIIOHandler::option(ImageOption option) const
 {
-    if (option == Size)
-    {
-        QFileDevice* d = dynamic_cast<QFileDevice*>(device());
+    const auto getImageInput = [](QIODevice* device) -> std::unique_ptr<oiio::ImageInput> {
+        QFileDevice* d = dynamic_cast<QFileDevice*>(device);
         if(!d)
         {
             qDebug() << "[QtOIIO] Read image failed (not a FileDevice).";
-            return false;
+            return std::unique_ptr<oiio::ImageInput>(nullptr);
         }
         std::string path = d->fileName().toStdString();
+        return std::unique_ptr<oiio::ImageInput>(oiio::ImageInput::open(path));
+    };
 
-        std::unique_ptr<oiio::ImageInput> imageInput(oiio::ImageInput::open(path));
+    if (option == Size)
+    {
+        std::unique_ptr<oiio::ImageInput> imageInput = getImageInput(device());
         if(imageInput.get() == nullptr)
             return QVariant();
 
         return QSize(imageInput->spec().width, imageInput->spec().height);
+    }
+    else if(option == ImageTransformation)
+    {
+        std::unique_ptr<oiio::ImageInput> imageInput = getImageInput(device());
+        if(imageInput.get() == nullptr)
+        {
+            return QImageIOHandler::TransformationNone;
+        }
+        // Translate OIIO transformations to QImageIOHandler::ImageTransformation
+        switch(oiio::ImageBuf(imageInput->spec()).orientation())
+        {
+        case 1: return QImageIOHandler::TransformationNone; break;
+        case 2: return QImageIOHandler::TransformationMirror; break;
+        case 3: return QImageIOHandler::TransformationRotate180; break;
+        case 4: return QImageIOHandler::TransformationFlip; break;
+        case 5: return QImageIOHandler::TransformationMirrorAndRotate90; break;
+        case 6: return QImageIOHandler::TransformationRotate90; break;
+        case 7: return QImageIOHandler::TransformationFlipAndRotate90; break;
+        case 8: return QImageIOHandler::TransformationRotate270; break;
+        }
     }
     return QImageIOHandler::option(option);
 }

--- a/src/imageIOHandler/QtOIIOPlugin.cpp
+++ b/src/imageIOHandler/QtOIIOPlugin.cpp
@@ -13,30 +13,29 @@ namespace oiio = OIIO;
 
 QtOIIOPlugin::QtOIIOPlugin()
 {
-    qInfo() << "[QtOIIO] init supported extensions.";
+    qDebug() << "[QtOIIO] init supported extensions.";
 
     std::string extensionsListStr;
     oiio::getattribute("extension_list", extensionsListStr);
 
     QString extensionsListQStr(QString::fromStdString(extensionsListStr));
-    // qInfo() << "[QtOIIO] extensionsListStr: " << extensionsListQStr << ".";
 
     QStringList formats = extensionsListQStr.split(';');
     for(auto& format: formats)
     {
-        qInfo() << "[QtOIIO] format: " << format << ".";
+        qDebug() << "[QtOIIO] format: " << format << ".";
         QStringList keyValues = format.split(":");
         if(keyValues.size() != 2)
         {
-            qInfo() << "[QtOIIO] warning: split OIIO keys: " << keyValues.size() << " for " << format << ".";
+            qDebug() << "[QtOIIO] warning: split OIIO keys: " << keyValues.size() << " for " << format << ".";
         }
         else
         {
             _supportedExtensions += keyValues[1].split(",");
         }
     }
-    qInfo() << "[QtOIIO] supported extensions: " << _supportedExtensions.join(", ");
-    std::cout << "[QtOIIO] supported extensions: " << _supportedExtensions.join(", ").toStdString() << std::endl;
+    qDebug() << "[QtOIIO] supported extensions: " << _supportedExtensions.join(", ");
+    qInfo() << "[QtOIIO] Plugin Initialized";
 }
 
 QtOIIOPlugin::~QtOIIOPlugin()
@@ -55,7 +54,7 @@ QImageIOPlugin::Capabilities QtOIIOPlugin::capabilities(QIODevice *device, const
 
     if (_supportedExtensions.contains(format, Qt::CaseSensitivity::CaseInsensitive))
     {
-        qInfo() << "[QtOIIO] Capabilities: extension \"" << QString(format) << "\" supported.";
+        qDebug() << "[QtOIIO] Capabilities: extension \"" << QString(format) << "\" supported.";
 //        oiio::ImageOutput *out = oiio::ImageOutput::create(path); // TODO: when writting will be implemented
         Capabilities capabilities(CanRead);
 //        if(out)
@@ -63,7 +62,7 @@ QImageIOPlugin::Capabilities QtOIIOPlugin::capabilities(QIODevice *device, const
 //        oiio::ImageOutput::destroy(out);
         return capabilities;
     }
-    qInfo() << "[QtOIIO] Capabilities: extension \"" << QString(format) << "\" not supported";
+    qDebug() << "[QtOIIO] Capabilities: extension \"" << QString(format) << "\" not supported";
     return 0;
 }
 

--- a/src/imageIOHandler/QtOIIOPlugin.cpp
+++ b/src/imageIOHandler/QtOIIOPlugin.cpp
@@ -52,6 +52,14 @@ QImageIOPlugin::Capabilities QtOIIOPlugin::capabilities(QIODevice *device, const
     if(path.empty() || path[0] == ':')
         return 0;
 
+#ifdef QTOIIO_USE_FORMATS_BLACKLIST
+    // For performance sake, let Qt handle natively some formats.
+    static const QStringList blacklist{"jpeg", "jpg", "png", "ico"};
+    if(blacklist.contains(format, Qt::CaseSensitivity::CaseInsensitive))
+    {
+        return 0;
+    }
+#endif
     if (_supportedExtensions.contains(format, Qt::CaseSensitivity::CaseInsensitive))
     {
         qDebug() << "[QtOIIO] Capabilities: extension \"" << QString(format) << "\" supported.";

--- a/src/imageIOHandler/QtOIIOPlugin.json
+++ b/src/imageIOHandler/QtOIIOPlugin.json
@@ -1,13 +1,9 @@
 {
   "Keys": [
-        "jpg", "jpeg",
-        "png",
         "exr",
         "bay", "bmq", "cr2", "crw", "cs1", "dc2", "dcr", "dng", "erf", "fff", "hdr", "k25", "kdc", "mdc", "mos", "mrw", "nef", "orf", "pef", "pxn", "raf", "raw", "rdc", "sr2", "srf", "x3f", "arw", "3fr", "cine", "ia", "kc2", "mef", "nrw", "qtk", "rw2", "sti", "rwl", "srw", "drf", "dsc", "ptx", "cap", "iiq", "rwz"
     ],
   "MimeTypes": [
-        "image/jpeg", "image/jpeg",
-        "image/png",
         "image/exr",
         "image/bay", "image/bmq", "image/cr2", "image/crw", "image/cs1", "image/dc2", "image/dcr", "image/dng", "image/erf", "image/fff", "image/hdr", "image/k25", "image/kdc", "image/mdc", "image/mos", "image/mrw", "image/nef", "image/orf", "image/pef", "image/pxn", "image/raf", "image/raw", "image/rdc", "image/sr2", "image/srf", "image/x3f", "image/arw", "image/3fr", "image/cine", "image/ia", "image/kc2", "image/mef", "image/nrw", "image/qtk", "image/rw2", "image/sti", "image/rwl", "image/srw", "image/drf", "image/dsc", "image/ptx", "image/cap", "image/iiq", "image/rwz"
     ]


### PR DESCRIPTION
Disable handling of JPGs, PNGs and interface only image formats (e.g: ico) by default.
Qt is faster loading/generating thumbnails for JPGs and PNGs. Also, let Qt handle images meant to be used inside the UI only. 
Make this plugin primarily useful to load EXR/RAW image formats (and other formats not handled by Qt).

- [X] disable support of JPG, PNG and UI only format(s) by default
- [X] support ImageTransformation instead of TransformedByDefault and let Qt perform image transformations.
- [X] don't install ".json" metadata file