### PR TITLE
[imageIO] fix colorspace handling depending on OIIO version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ platform:
   - x64
 
 environment:
-  QT5: C:\Qt\5.11.2\msvc2017_64
+  QT5: C:\Qt\5.12.2\msvc2017_64
   # APPVEYOR_SAVE_CACHE_ON_ERROR: true
 
 install:


### PR DESCRIPTION
Follow the changes in oiio to manage colorspaces on RAW images, see: OpenImageIO/oiio#2260 and alicevision/AliceVision/pull/645.