### PR TITLE
Handle NaN in images when using jetColorMap

### DIFF
--- a/src/depthMapEntity/DepthMapEntity.cpp
+++ b/src/depthMapEntity/DepthMapEntity.cpp
@@ -328,7 +328,8 @@ void DepthMapEntity::loadDepthMap()
             }
             else
             {
-                float normalizedDepthValue = (depthValue - stats.min[0]) / (stats.max[0] - stats.min[0]);
+                const float range = stats.max[0] - stats.min[0];
+                float normalizedDepthValue = range != 0.0f ? (depthValue - stats.min[0]) / range : 1.0f;
                 Color32f color = getColor32fFromJetColorMapClamp(normalizedDepthValue);
                 colors.push_back(color);
             }

--- a/src/imageIOHandler/QtOIIOHandler.cpp
+++ b/src/imageIOHandler/QtOIIOHandler.cpp
@@ -216,7 +216,8 @@ bool QtOIIOHandler::read(QImage *image)
                 {
                     float depthValue = 0.0f;
                     inBuf.getpixel(x, y, &depthValue, 1);
-                    float normalizedDepthValue = (depthValue - stats.min[0]) / (stats.max[0] - stats.min[0]);
+                    const float range = stats.max[0] - stats.min[0];
+                    const float normalizedDepthValue = range != 0.0f ? (depthValue - stats.min[0]) / range : 1.0f;
                     Color32f color;
                     if(isDepthMap)
                         color = getColor32fFromJetColorMap(normalizedDepthValue);

--- a/src/jetColorMap.hpp
+++ b/src/jetColorMap.hpp
@@ -41,6 +41,8 @@ struct Color32f
 
 inline Color32f getColor32fFromJetColorMap(float value)
 {
+    if(std::isnan(value))
+        return Color32f(1.0f, 0.0f, 1.0f);
     if(value <= 0.0f)
         return Color32f(0, 0, 0);
     if(value >= 1.0f)
@@ -59,6 +61,8 @@ inline Color32f getColor32fFromJetColorMap(float value)
 
 inline Color32f getColor32fFromJetColorMapClamp(float value)
 {
+    if(std::isnan(value))
+        return Color32f(1.0f, 0.0f, 1.0f);
     if(value < 0.0f)
         value = 0.0f;
     if(value > 1.0f)


### PR DESCRIPTION
Fix crash when remapping images containing NaNs using jetColorMap (e.g: AliceVision depthmaps).