### PR TITLE
[depthMap] better handling of non-depthmap files + expose status

### DIFF
--- a/src/depthMapEntity/DepthMapEntity.hpp
+++ b/src/depthMapEntity/DepthMapEntity.hpp
@@ -19,11 +19,22 @@ class DepthMapEntity : public Qt3DCore::QEntity
     Q_ENUMS(DisplayMode)
 
     Q_PROPERTY(QUrl source READ source WRITE setSource NOTIFY sourceChanged);
+    Q_PROPERTY(Status status READ status NOTIFY statusChanged)
     Q_PROPERTY(DisplayMode displayMode READ displayMode WRITE setDisplayMode NOTIFY displayModeChanged);
     Q_PROPERTY(bool displayColor READ displayColor WRITE setDisplayColor NOTIFY displayColorChanged);
     Q_PROPERTY(float pointSize READ pointSize WRITE setPointSize NOTIFY pointSizeChanged);
 
 public:
+
+    // Identical to SceneLoader.Status
+    enum Status { 
+        None = 0,
+        Loading,
+        Ready,
+        Error
+    };
+    Q_ENUM(Status)
+
     DepthMapEntity(Qt3DCore::QNode* = nullptr);
     ~DepthMapEntity() = default;
 
@@ -36,6 +47,15 @@ public:
 public:
     Q_SLOT const QUrl& source() const { return _source; }
     Q_SLOT void setSource(const QUrl&);
+
+    Status status() const { return _status; }
+
+    void setStatus(Status status) { 
+        if(status == _status) 
+            return; 
+        _status = status; 
+        Q_EMIT statusChanged(_status); 
+    }
 
     Q_SLOT DisplayMode displayMode() const { return _displayMode; }
     Q_SLOT void setDisplayMode(const DisplayMode&);
@@ -53,11 +73,13 @@ private:
 
 public:
     Q_SIGNAL void sourceChanged();
+    Q_SIGNAL void statusChanged(Status status);
     Q_SIGNAL void displayModeChanged();
     Q_SIGNAL void displayColorChanged();
     Q_SIGNAL void pointSizeChanged();
 
 private:
+    Status _status = DepthMapEntity::None;
     QUrl _source;
     DisplayMode _displayMode = DisplayMode::Triangles;
     bool _displayColor = true;

--- a/src/depthMapEntity/plugin.hpp
+++ b/src/depthMapEntity/plugin.hpp
@@ -17,7 +17,7 @@ public:
     void registerTypes(const char* uri) override
     {
         Q_ASSERT(uri == QLatin1String("DepthMapEntity"));
-        qmlRegisterType<DepthMapEntity>(uri, 2, 0, "DepthMapEntity");
+        qmlRegisterType<DepthMapEntity>(uri, 2, 1, "DepthMapEntity");
     }
 };
 


### PR DESCRIPTION
Expose loading status of DepthMapEntity.

- [X] add status property that reflects the loading status of DepthMapEntity
- [X] early return when source is not a recognized depthMap file and set status to Error