### PR TITLE
Qt6 compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,18 @@ message("CMake version: ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}")
 cmake_minimum_required(VERSION 3.4)
 project(QtOIIO LANGUAGES CXX C)
 
-# C++11
-set(CMAKE_CXX_STANDARD 11)
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
+
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+# C++11 for Qt5
+if(${QT_VERSION_MAJOR} EQUAL 5)
+    set(CMAKE_CXX_STANDARD 11)
+endif()
+
+# C++17 for Qt6
+if(${QT_VERSION_MAJOR} EQUAL 6)
+    set(CMAKE_CXX_STANDARD 17)
+endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
@@ -12,19 +21,22 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 # OpenImageIO
 find_package(OpenImageIO REQUIRED)
 if(OPENIMAGEIO_FOUND)
-  message(STATUS "OpenImageIO found.")
+    message(STATUS "OpenImageIO found.")
 else()
-  message(SEND_ERROR "Failed to find OpenImageIO.")
+    message(SEND_ERROR "Failed to find OpenImageIO.")
 endif()
 
 
 # Qt
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON) # needed for automoc
-find_package(Qt5Core REQUIRED)
-find_package(Qt5Widgets REQUIRED)
-if(Qt5Core_FOUND)
-  message(STATUS "Qt5 found.")
+
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Widgets REQUIRED)
+
+
+if(Qt${QT_VERSION_MAJOR}Core_FOUND)
+    message(STATUS "Qt ${QT_VERSION_MAJOR}.${QT_VERSION_MINOR} found.")
 endif()
 
 add_definitions(-DQT_PLUGIN)
@@ -39,5 +51,12 @@ add_definitions(-DQT_NO_DEBUG_OUTPUT)
 add_definitions(-DQTOIIO_USE_FORMATS_BLACKLIST)
 
 add_subdirectory(src/imageIOHandler)
-add_subdirectory(src/depthMapEntity)
 
+# TODO: Make it works for Qt6
+# Add to Qt5 only for the moment since 3dcore
+# is not part of the distribution anymore.
+# Source: https://www.kdab.com/qt-3d-changes-in-qt-6/
+if(Qt5_FOUND)
+    add_subdirectory(src/depthMapEntity)
+endif()
+# add_subdirectory(src/depthMapEntity)

--- a/src/depthMapEntity/CMakeLists.txt
+++ b/src/depthMapEntity/CMakeLists.txt
@@ -1,14 +1,12 @@
 # Target srcs
 file(GLOB_RECURSE TARGET_SRCS *.cpp *.cxx *.cc *.C *.c *.h *.hpp)
 
-
-find_package(Qt5Gui)
-find_package(Qt5Qml)
-find_package(Qt5Quick)
-find_package(Qt53DCore)
-find_package(Qt53DRender)
-find_package(Qt53DExtras)
-
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Gui REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Qml REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Quick REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS 3DCore REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS 3DRender REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS 3DExtras REQUIRED)
 
 # Target properties
 add_library(depthMapEntityQmlPlugin SHARED ${TARGET_SRCS})
@@ -22,12 +20,17 @@ target_link_libraries(depthMapEntityQmlPlugin
     PUBLIC
     ${OPENIMAGEIO_LIBRARIES}
     )
-if(Qt5Core_FOUND)
-  target_link_libraries(depthMapEntityQmlPlugin
+
+target_link_libraries(depthMapEntityQmlPlugin
       PUBLIC
-      Qt5::Core Qt5::Gui Qt5::Qml Qt5::Quick Qt5::3DCore Qt5::3DRender Qt5::3DExtras
+      Qt${QT_VERSION_MAJOR}::Core
+      Qt${QT_VERSION_MAJOR}::Gui
+      Qt${QT_VERSION_MAJOR}::Qml
+      Qt${QT_VERSION_MAJOR}::Quick
+      Qt${QT_VERSION_MAJOR}::3DCore
+      Qt${QT_VERSION_MAJOR}::3DRender
+      Qt${QT_VERSION_MAJOR}::3DExtras
       )
-endif()
 
 # QT5_USE_MODULES(depthMapEntityQmlPlugin Core Qml Quick 3DCore 3DRender 3DExtras ${OPENIMAGEIO_LIBRARIES})
 

--- a/src/imageIOHandler/CMakeLists.txt
+++ b/src/imageIOHandler/CMakeLists.txt
@@ -21,11 +21,10 @@ target_link_libraries(QtOIIOPlugin
     PUBLIC
     ${OPENIMAGEIO_LIBRARIES}
     )
-if(Qt5Core_FOUND)
-  target_link_libraries(QtOIIOPlugin
-      PUBLIC
-      Qt5::Core Qt5::Gui
-      )
-endif()
+
+target_link_libraries(QtOIIOPlugin
+    PUBLIC
+    Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Gui
+    )
 
 install(TARGETS QtOIIOPlugin DESTINATION imageformats)

--- a/src/imageIOHandler/QtOIIOPlugin.cpp
+++ b/src/imageIOHandler/QtOIIOPlugin.cpp
@@ -1,7 +1,7 @@
 #include "QtOIIOPlugin.hpp"
 #include "QtOIIOHandler.hpp"
 
-#include <qimageiohandler.h>
+#include <QImageIOHandler>
 #include <QFileDevice>
 #include <QDebug>
 
@@ -46,18 +46,18 @@ QImageIOPlugin::Capabilities QtOIIOPlugin::capabilities(QIODevice *device, const
 {
     QFileDevice* d = dynamic_cast<QFileDevice*>(device);
     if(!d)
-        return 0;
+        return QImageIOPlugin::Capabilities();
 
     const std::string path = d->fileName().toStdString();
     if(path.empty() || path[0] == ':')
-        return 0;
+        return QImageIOPlugin::Capabilities();
 
 #ifdef QTOIIO_USE_FORMATS_BLACKLIST
     // For performance sake, let Qt handle natively some formats.
     static const QStringList blacklist{"jpeg", "jpg", "png", "ico"};
     if(blacklist.contains(format, Qt::CaseSensitivity::CaseInsensitive))
     {
-        return 0;
+        return QImageIOPlugin::Capabilities();
     }
 #endif
     if (_supportedExtensions.contains(format, Qt::CaseSensitivity::CaseInsensitive))
@@ -71,7 +71,7 @@ QImageIOPlugin::Capabilities QtOIIOPlugin::capabilities(QIODevice *device, const
         return capabilities;
     }
     qDebug() << "[QtOIIO] Capabilities: extension \"" << QString(format) << "\" not supported";
-    return 0;
+    return QImageIOPlugin::Capabilities();
 }
 
 QImageIOHandler *QtOIIOPlugin::create(QIODevice *device, const QByteArray &format) const


### PR DESCRIPTION
Hi,

Just getting the project to compile with Qt6.0.1.
I was not able to compile the depthMapEntity subdirectory but the imageIOHandler works fine in PySide6.

depthMapEntity compilation leads to a:
`Could NOT find Qt63DCore (missing: Qt63DCore_DIR)`

Tried to compile it from the `AdditionalLibraries/Qt/qt3d-6.0.1/Src` from the Qt installer, but the cmake files seems to be missing even after a successful compilation.

I was able to fully compile the project for Qt5.13.2 and Qt5.15.2.

```
% tree dist-*
dist-5.13.2
├── imageformats
│   └── libQtOIIOPlugin.dylib
└── qml
    └── DepthMapEntity
        ├── libdepthMapEntityQmlPlugin.dylib
        └── qmldir
dist-5.15.2
├── imageformats
│   └── libQtOIIOPlugin.dylib
└── qml
    └── DepthMapEntity
        ├── libdepthMapEntityQmlPlugin.dylib
        └── qmldir
dist-6.0.1
└── imageformats
    └── libQtOIIOPlugin.dylib
```

Hope this helps.

Cheers !